### PR TITLE
Fix jq executable name for release 1.7 and support arm64

### DIFF
--- a/package/jq.tengo
+++ b/package/jq.tengo
@@ -4,7 +4,7 @@ text := import("text")
 nami := import("nami")
 json := import("json")
 
-b := nami.sh1(`curl`, `-L`, `https://api.github.com/repos/stedolan/jq/releases/latest`)
+b := nami.sh1(`curl`, `-L`, `https://api.github.com/repos/jqlang/jq/releases/latest`)
 if is_error(b) {
     fmt.println(b)
     os.exit(1)
@@ -17,20 +17,13 @@ if is_error(err) {
 }
 
 got := false
-if nami.os == "darwin" {
+if (nami.os == "linux" || nami.os == "darwin") && (nami.arch == "amd64" || nami.arch == "arm64") {
     got = true
-    if nami.arch == "arm64" {
-        fmt.println("There is no arm64 version, will download amd64 version for you!")
+    s := nami.os
+    if s == "darwin" {
+        s = "macos"
     }
-    err := nami.sh(`curl`, `-L`, `--progress-bar`, `https://github.com/stedolan/jq/releases/latest/download/jq-osx-amd64`, `-o`, text.join([nami.cache_dir, "jq"], os.path_separator))
-    if is_error(err) {
-        fmt.println(err)
-        os.exit(1)
-    }
-}
-if nami.os == "linux" && nami.arch == "amd64" {
-    got = true
-    err := nami.sh(`curl`, `-L`, `--progress-bar`, `https://github.com/stedolan/jq/releases/latest/download/jq-linux64`, `-o`, text.join([nami.cache_dir, "jq"], os.path_separator))
+    err := nami.sh(`curl`, `-L`, `--progress-bar`, `https://github.com/jqlang/jq/releases/latest/download/jq-`+s+`-`+nami.arch, `-o`, text.join([nami.cache_dir, "jq"], os.path_separator))
     if is_error(err) {
         fmt.println(err)
         os.exit(1)
@@ -38,7 +31,7 @@ if nami.os == "linux" && nami.arch == "amd64" {
 }
 if nami.os == "windows" && nami.arch == "amd64" {
     got = true
-    err := nami.sh(`curl`, `-L`, `--progress-bar`, `https://github.com/stedolan/jq/releases/latest/download/jq-win64`, `-o`, text.join([nami.cache_dir, "jq.exe"], os.path_separator))
+    err := nami.sh(`curl`, `-L`, `--progress-bar`, `https://github.com/jqlang/jq/releases/latest/download/jq-windows-amd64.exe`, `-o`, text.join([nami.cache_dir, "jq.exe"], os.path_separator))
     if is_error(err) {
         fmt.println(err)
         os.exit(1)

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@ Defaults        !env_reset
 | jinbe | Jinbe can add auto start command at boot. Zero-Configuration. Jinbe 可以添加开机自动启动命令. 无需配置. | [Website](https://github.com/txthinking/jinbe) |
 | joker | Joker can turn process into daemon. Zero-Configuration. Joker 可以将进程变成守护进程. 无需配置. | [Website](https://github.com/txthinking/joker) |
 | jb |  jb = javascript + bash | [Website](https://github.com/txthinking/jb) |
-| jq | Command-line JSON processor | [Website](https://github.com/stedolan/jq) |
+| jq | Command-line JSON processor | [Website](https://github.com/jqlang/jq) |
 | mad | Generate root CA and derivative certificate for any domains and any IPs. 为任何域名和 IP 生成证书 | [Website](https://github.com/txthinking/mad) |
 | markdown | markdown converter | [Website](https://github.com/txthinking/markdown) |
 | marp | A CLI interface for Marp and Marpit based converters | [Website](https://github.com/marp-team/marp-cli) |


### PR DESCRIPTION
In [jq 1.7](https://github.com/jqlang/jq/releases/tag/jq-1.7), jq maintainers changed executable names to support various CPU architectures.
Previously something like `jq-linux64` but now `jq-linux-amd64` and `jq-linux-arm64`.
They temporarily added the executable with old names to fix for the latest URLs (https://github.com/jqlang/jq/issues/2877).
But they might not retain the executable with the old names. This PR also add support for the arm64 architecture.