### PR TITLE
fix writing to `~/.bash_profile` will prevent `~/.bashrc` being sourced

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,13 +37,15 @@ curl -L -o /tmp/nami$sfx "https://github.com/txthinking/nami/releases/latest/dow
 chmod +x /tmp/nami$sfx
 /tmp/nami$sfx install nami
 
-echo 'if [ -d $HOME/.nami/bin ]; then' >>$HOME/.bashrc
-echo '    export PATH=$HOME/.nami/bin:$PATH' >>$HOME/.bashrc
-echo 'fi' >>$HOME/.bashrc
 
-echo 'if [ -d $HOME/.nami/bin ]; then' >>$HOME/.bash_profile
-echo '    export PATH=$HOME/.nami/bin:$PATH' >>$HOME/.bash_profile
-echo 'fi' >>$HOME/.bash_profile
-
-echo source ~/.bashrc >>$HOME/.zshenv
-echo source ~/.bash_profile >>$HOME/.zshenv
+if [ -f $HOME/.bash_profile ]; then
+    echo 'if [ -d $HOME/.nami/bin ]; then' >>$HOME/.bash_profile
+    echo '    export PATH=$HOME/.nami/bin:$PATH' >>$HOME/.bash_profile
+    echo 'fi' >>$HOME/.bash_profile
+    echo source ~/.bash_profile >>$HOME/.zshenv
+elif [ -f $HOME/.bashrc ]; then
+    echo 'if [ -d $HOME/.nami/bin ]; then' >>$HOME/.bashrc
+    echo '    export PATH=$HOME/.nami/bin:$PATH' >>$HOME/.bashrc
+    echo 'fi' >>$HOME/.bashrc
+    echo source ~/.bashrc >>$HOME/.zshenv
+fi


### PR DESCRIPTION
为什么要这样做？至少在ubuntu上，如果bash_profile存在，那么bashrc里的内容将不会被执行。

https://superuser.com/questions/183870/difference-between-bashrc-and-bash-profile